### PR TITLE
Changed way to run examples

### DIFF
--- a/lib/tasks/zastavskyi/zastavskyi_5.rb
+++ b/lib/tasks/zastavskyi/zastavskyi_5.rb
@@ -18,11 +18,3 @@ def find(seq)
   seq[i] + d
 end
 
-if $PROGRAM_NAME == __FILE__
-  sequences = [
-                [1, 3, 5, 9],
-                [120, 240, 480]
-              ]
-sequences.each { |sequence| puts "Sequence: #{sequence}\nMissing element: #{find(sequence)}" }
-end
-

--- a/lib/tasks/zastavskyi/zastavskyi_6.rb
+++ b/lib/tasks/zastavskyi/zastavskyi_6.rb
@@ -15,9 +15,3 @@ def multiplication_table(size)
   res
 end
 
-if $PROGRAM_NAME == __FILE__
-n = 6
-puts "Multiplication table with size #{n}"
-table = multiplication_table(n)
-table.each { |row| p row }
-end

--- a/lib/tasks/zastavskyi/zastavskyi_7.rb
+++ b/lib/tasks/zastavskyi/zastavskyi_7.rb
@@ -12,10 +12,3 @@ def stray(numbers)
   numbers
 end
 
-if $PROGRAM_NAME == __FILE__
-sequences = [
-[1, 1, 1, 3, 1],
-[0, 0, 1, 0, 0]
-]
-sequences.each { |sequence| puts "Sequence: #{sequence}\nDifferent element: #{stray(sequence)}" }
-end

--- a/lib/tasks/zastavskyi/zastavskyi_8_1.rb
+++ b/lib/tasks/zastavskyi/zastavskyi_8_1.rb
@@ -19,7 +19,3 @@ def remove_exclamation_marks(input_string)
   string                   # return result string
 end
 
-if $PROGRAM_NAME == __FILE__
-strings = ['hello!', 'world!!', '!for!', 'every!one!!']
-strings.each { |string| puts "String: #{string}\nChanged string: #{remove_exclamation_marks(string)}" }
-end

--- a/lib/tasks/zastavskyi/zastavskyi_8_2.rb
+++ b/lib/tasks/zastavskyi/zastavskyi_8_2.rb
@@ -16,7 +16,3 @@ def dna_to_rna(dna)
   dna.upcase.gsub('T', 'U')
 end
 
-if $PROGRAM_NAME == __FILE__
-strings = ['TAGCTAGC', 'TAATTAGCCAT']
-strings.each { |string| puts "DNA: #{string}\nRNA: #{dna_to_rna(string)}" }
-end

--- a/spec/run_examples.rb
+++ b/spec/run_examples.rb
@@ -1,0 +1,41 @@
+require_relative 'spec_helper'
+
+examples = {
+  'zastavskyi' => [proc do
+    sequences = [
+      [1, 3, 5, 9],
+      [120, 240, 480]
+    ]
+    sequences.each { |sequence| puts "Sequence: #{sequence}\nMissing element: #{find(sequence)}" }
+  end,
+                   proc do
+                     n = 6
+                     puts "Multiplication table with size #{n}"
+                     table = multiplication_table(n)
+                     table.each { |row| p row }
+                   end,
+                   proc do
+                     sequences = [
+                       [1, 1, 1, 3, 1],
+                       [0, 0, 1, 0, 0]
+                     ]
+                     sequences.each do |sequence|
+                       puts "Sequence: #{sequence}\nDifferent element: #{stray(sequence)}"
+                     end
+                   end,
+                   proc do
+                     strings = ['hello!', 'world!!', '!for!', 'every!one!!']
+                     strings.each do |string|
+                       puts "String: #{string}\nChanged string: #{remove_exclamation_marks(string)}"
+                     end
+                   end,
+                   proc do
+                     strings = %w[TAGCTAGC TAATTAGCCAT]
+                     strings.each { |string| puts "DNA: #{string}\nRNA: #{dna_to_rna(string)}" }
+                   end]
+}
+
+examples.default = [proc do puts 'Invalid name' end] * 5
+name = gets.chomp
+num = gets.chomp.to_i
+examples[name][num].call


### PR DESCRIPTION
I have changed way to run examples.
Now all examples are located in spec/run_examples.rb instead of files with katas.
There`s left to do the same changes with other katas and modify the run command  